### PR TITLE
Add -trimpath to go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOGENERATE=$(GOCMD) generate
 GOTEST=$(GOCMD) test
+GOBUILDFLAGS= "-trimpath"
 
 .PHONY: devel-deps
 devel-deps:
@@ -22,7 +23,7 @@ devel-deps:
 
 .PHONY: build
 build:
-	$(GOBUILD) -o $(BINDIR)/$(BINNAME) -v 
+	$(GOBUILD) -o $(BINDIR)/$(BINNAME) -v $(GOBUILDFLAGS)
 
 .PHONY: test
 test:


### PR DESCRIPTION
- goxz does not implement additional args.
- Issue on goxz for implementing this https://github.com/Songmu/goxz/issues/23