### PR TITLE
global: treat multiple inventories as one for the same platform

### DIFF
--- a/internal/pkg/ansible/ansible.go
+++ b/internal/pkg/ansible/ansible.go
@@ -11,7 +11,7 @@ type (
 	}
 
 	CommonArgs struct {
-		Inventories          []string
+		Inventories          [][]string
 		HideDiff, BecomeSudo bool
 		CheckModeEnabled     bool
 		JoinInventories      bool
@@ -36,8 +36,12 @@ func (cargs CommonArgs) buildCommonArgs() []string {
 	return result
 }
 
-func buildInventoryArg(inventory string) []string {
-	return []string{"--inventory", inventory}
+func buildInventoryArg(inventories []string) []string {
+	var a []string
+	for _, inv := range inventories {
+		a = append(a, "--inventory", inv)
+	}
+	return a
 }
 
 func (cargs CommonArgs) joinInventories() []string {
@@ -52,4 +56,23 @@ func (cargs CommonArgs) printInventories(writer io.Writer) {
 	for _, inv := range cargs.Inventories {
 		fmt.Fprintln(writer, "inventory:", inv)
 	}
+}
+
+func isInventoriesEmpty(inventories [][]string) bool {
+	if len(inventories) == 0 {
+		return true
+	}
+	for _, invs := range inventories {
+		if len(invs) == 0 {
+			return true
+		}
+		for _, inv := range invs {
+			if len(inv) == 0 {
+				return true
+			}
+
+		}
+	}
+
+	return false
 }

--- a/internal/pkg/ansible/playbook.go
+++ b/internal/pkg/ansible/playbook.go
@@ -31,7 +31,7 @@ func InitPlaybookExecutor(cmdExecutor CommandExecutor, playbookBinPath, playbook
 }
 
 func (play Playbook) Play(playbookName string) error {
-	if len(play.Inventories) == 0 {
+	if isInventoriesEmpty(play.Inventories) {
 		return fmt.Errorf("playbook: no inventory to work on")
 	}
 

--- a/internal/pkg/ansible/playbook_test.go
+++ b/internal/pkg/ansible/playbook_test.go
@@ -17,22 +17,22 @@ func TestPlaybookExecutorPlay(t *testing.T) {
 	fullPlaybookPath := filepath.Join(playbookRepoPath, playbookName)
 	tests := []struct {
 		name              string
-		inventories       []string
+		inventories       [][]string
 		joinedInventories bool
 		args              []string
 		err               error
 	}{
-		{"empty inventories", []string{}, false, []string{}, errors.New("playbook: no inventory to work on")},
+		{"empty inventories", [][]string{}, false, []string{}, errors.New("playbook: no inventory to work on")},
 		{
 			"successfull run",
-			[]string{"inventory1", "inventory2", "inventory3"},
+			[][]string{{"inventory1"}, {"inventory2"}, {"inventory3"}},
 			false,
 			[]string{"--diff", "--inventory"},
 			nil,
 		},
 		{
 			"successfull join run",
-			[]string{"inventory1", "inventory2", "inventory3"},
+			[][]string{{"inventory1"}, {"inventory2"}, {"inventory3"}},
 			true,
 			[]string{"--diff", "--inventory", "inventory1", "--inventory", "inventory2", "--inventory", "inventory3"},
 			nil,
@@ -59,12 +59,14 @@ func TestPlaybookExecutorPlay(t *testing.T) {
 						Return(nil).
 						Times(1)
 				} else {
-					for _, inventory := range tt.inventories {
-						completeArgs := append(tt.args, inventory, fullPlaybookPath)
-						m.EXPECT().
-							Run(playbookBinPath, completeArgs).
-							Return(nil).
-							Times(1)
+					for _, inventories := range tt.inventories {
+						for _, inventory := range inventories {
+							completeArgs := append(tt.args, inventory, fullPlaybookPath)
+							m.EXPECT().
+								Run(playbookBinPath, completeArgs).
+								Return(nil).
+								Times(1)
+						}
 					}
 				}
 			}

--- a/internal/pkg/ansible/run.go
+++ b/internal/pkg/ansible/run.go
@@ -45,10 +45,12 @@ func (runMod RunModule) Run() error {
 	if runMod.debug {
 		runMod.printInventories(runMod.stdout)
 	}
+
+	if isInventoriesEmpty(runMod.Inventories) {
+		return fmt.Errorf("run: inventory is empty")
+	}
+
 	for _, inventory := range runMod.Inventories {
-		if len(inventory) == 0 {
-			return fmt.Errorf("run: inventory is empty")
-		}
 		if runMod.debug {
 			fmt.Fprintf(runMod.stdout, "Start running %s module on %s inventory...\n",
 				runMod.ModuleName, inventory)
@@ -62,7 +64,7 @@ func (runMod RunModule) Run() error {
 	return nil
 }
 
-func (runMod RunModule) computeAnsibleOptions(inventory string) []string {
+func (runMod RunModule) computeAnsibleOptions(inventory []string) []string {
 	var result = runMod.buildCommonArgs()
 	result = append(result, buildInventoryArg(inventory)...)
 	result = append(result, "-m", runMod.ModuleName)

--- a/internal/pkg/environment/finder.go
+++ b/internal/pkg/environment/finder.go
@@ -65,11 +65,11 @@ func FindEnvironmentTreeFromPredicate(predicate *ParsedPredicate, envs *Environm
 	return env, nil
 }
 
-func GetFullPathInventoriesFromEnvironments(basePath string, envs Environments) ([]string, error) {
+func GetFullPathInventoriesFromEnvironments(basePath string, envs Environments) ([][]string, error) {
 	if envs == nil {
 		return nil, fmt.Errorf("environment: environment tree is nil")
 	}
-	var globalInventories []string
+	var globalInventories [][]string
 
 	for _, env := range envs {
 		if env.Descriptions == nil {
@@ -85,9 +85,12 @@ func GetFullPathInventoriesFromEnvironments(basePath string, envs Environments) 
 					return nil, fmt.Errorf("environment: no inventories")
 				}
 
-				for _, relativePath := range platform.Inventories {
-					globalInventories = append(globalInventories, filepath.Join(basePath, relativePath))
+				invs := make([]string, len(platform.Inventories))
+				for i, relativePath := range platform.Inventories {
+					invs[i] = filepath.Join(basePath, relativePath)
 				}
+
+				globalInventories = append(globalInventories, invs)
 			}
 		}
 


### PR DESCRIPTION
- Use multi-dimentional arrays
- One platform with multiple inventories must be treated as a single
inventory

- Needed for #https://github.com/peopledoc/peopleinfra/issues/8099